### PR TITLE
DOD Customer's will need to login to AzureGovernment to access their environment

### DIFF
--- a/Sparrow.ps1
+++ b/Sparrow.ps1
@@ -147,16 +147,6 @@ Function Get-UALData {
 Function Get-AzureDomains{
 
     [cmdletbinding()]Param()
-
-    $govCloudPrompt = Read-Host -Prompt 'Is your Azure environment in Commercial or Government? (Y/N): '
-    #Connect to AzureAD or Azure Government based on the prompt | You're in USGOV Azure if you go to portal.azure.us 
-    if($govCloudPrompt -eq 'Y')
-    {
-        Connect-AzureAD -AzureEnvironmentName "AzureUSGovernment"
-    }
-    else {
-        Connect-AzureAD 
-    }
     
     $DomainData = Get-AzureADDomain
     $DomainArr = @()
@@ -187,14 +177,6 @@ Function Get-AzureSPAppRoles{
 
     #Connect to your tenant's AzureAD environment
     #Connect to AzureAD or Azure Government based on the prompt
-    if($govCloudPrompt -eq 'Y')
-    {
-        Connect-AzureAD -AzureEnvironmentName "AzureUSGovernment"
-    }
-    else {
-        Connect-AzureAD 
-    }
-
     #Retrieve all service principals that are applications
     $SPArr = Get-AzureADServicePrincipal -All $true | Where-Object {$_.ServicePrincipalType -eq "Application"}
 
@@ -385,5 +367,15 @@ Function Export-UALData {
 #Function calls, if you do not need a particular check, you can comment it out below with #
 Check-PSModules -Verbose
 Get-UALData -Verbose
+# Login to Azure/AzureGovernment
+$GovCloudPrompt = Read-Host -Prompt 'Is your Azure environment in Commercial or Government? (Y/N): '
+if($GovCloudPrompt -eq 'Y')
+{
+    Connect-AzureAD -AzureEnvironmentName "AzureUSGovernment"
+}
+else {
+    Connect-AzureAD 
+}
+
 Get-AzureDomains -Verbose
 Get-AzureSPAppRoles -Verbose

--- a/Sparrow.ps1
+++ b/Sparrow.ps1
@@ -147,6 +147,16 @@ Function Get-UALData {
 Function Get-AzureDomains{
 
     [cmdletbinding()]Param()
+
+    $GovCloudPrompt = Read-Host -Prompt 'Is your Azure environment in Commercial or Government? (Y/N): '
+    #Connect to AzureAD or Azure Government based on the prompt | You're in USGOV Azure if you go to portal.azure.us 
+    if($GovCloudPrompt -eq 'Y')
+    {
+        Connect-AzureAD -AzureEnvironmentName "AzureUSGovernment"
+    }
+    else {
+        Connect-AzureAD 
+    }
     
     $DomainData = Get-AzureADDomain
     $DomainArr = @()
@@ -177,6 +187,16 @@ Function Get-AzureSPAppRoles{
 
     #Connect to your tenant's AzureAD environment
     #Connect to AzureAD or Azure Government based on the prompt
+    $GovCloudPrompt = Read-Host -Prompt 'Is your Azure environment in Commercial or Government? (Y/N): '
+
+    if($GovCloudPrompt -eq 'Y')
+    {
+        Connect-AzureAD -AzureEnvironmentName "AzureUSGovernment"
+    }
+    else {
+        Connect-AzureAD 
+    }
+
     #Retrieve all service principals that are applications
     $SPArr = Get-AzureADServicePrincipal -All $true | Where-Object {$_.ServicePrincipalType -eq "Application"}
 
@@ -366,16 +386,6 @@ Function Export-UALData {
 
 #Function calls, if you do not need a particular check, you can comment it out below with #
 Check-PSModules -Verbose
-Get-UALData -Verbose
-# Login to Azure/AzureGovernment
-$GovCloudPrompt = Read-Host -Prompt 'Is your Azure environment in Commercial or Government? (Y/N): '
-if($GovCloudPrompt -eq 'Y')
-{
-    Connect-AzureAD -AzureEnvironmentName "AzureUSGovernment"
-}
-else {
-    Connect-AzureAD 
-}
-
+#Get-UALData -Verbose
 Get-AzureDomains -Verbose
 Get-AzureSPAppRoles -Verbose

--- a/Sparrow.ps1
+++ b/Sparrow.ps1
@@ -148,9 +148,16 @@ Function Get-AzureDomains{
 
     [cmdletbinding()]Param()
 
-    #Connect to AzureAD
-    Connect-AzureAD
-
+    $govCloudPrompt = Read-Host -Prompt 'Is your Azure environment in Commercial or Government? (Y/N): '
+    #Connect to AzureAD or Azure Government based on the prompt | You're in USGOV Azure if you go to portal.azure.us 
+    if($govCloudPrompt -eq 'Y')
+    {
+        Connect-AzureAD -AzureEnvironmentName "AzureUSGovernment"
+    }
+    else {
+        Connect-AzureAD 
+    }
+    
     $DomainData = Get-AzureADDomain
     $DomainArr = @()
     
@@ -179,7 +186,14 @@ Function Get-AzureSPAppRoles{
     [cmdletbinding()]Param()
 
     #Connect to your tenant's AzureAD environment
-    Connect-AzureAD
+    #Connect to AzureAD or Azure Government based on the prompt
+    if($govCloudPrompt -eq 'Y')
+    {
+        Connect-AzureAD -AzureEnvironmentName "AzureUSGovernment"
+    }
+    else {
+        Connect-AzureAD 
+    }
 
     #Retrieve all service principals that are applications
     $SPArr = Get-AzureADServicePrincipal -All $true | Where-Object {$_.ServicePrincipalType -eq "Application"}

--- a/Sparrow.ps1
+++ b/Sparrow.ps1
@@ -386,6 +386,6 @@ Function Export-UALData {
 
 #Function calls, if you do not need a particular check, you can comment it out below with #
 Check-PSModules -Verbose
-#Get-UALData -Verbose
+Get-UALData -Verbose
 Get-AzureDomains -Verbose
 Get-AzureSPAppRoles -Verbose


### PR DESCRIPTION

## 🗣 Description ##

For AzureGov & AzureDoD Customers a flag/prompt is added so that they can authenticate into the right Azure tenant and have the scans generate actual results. 
 
## 💭 Motivation and Context ##

This change is required so that AzureGov and AzureDoD customers can take what CISA has made and use it in their environments without needing to manually go in and find where the authentication switches are. The prompt and if statement handles that so the customer can get their results as soon as possible.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
I tested this inside my AzureDoD Cloud tenant just now and was able to validate the results matched with what I had on documentation for both my domains and service principals that can perform MSGraph calls.
<!-- Include details of your testing environment, and the tests you ran to -->
The testing environment was inside of the CloudOne Azure environment. Anyone in AzureGov or AzureDoD should be able to run this and get results that they are expecting. 

## 📷 Screenshots (if appropriate) ##

No screenshots as I do not want our TenantID or domain to be public at this time.


## ✅ Checklist ##



* [ ] This PR has an informative and human-readable title.
* [ ] Changes are limited to a single goal - _eschew scope creep!_
* [ ] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [ ] All relevant type-of-change labels have been added.
* [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [ ] Tests have been added and/or modified to cover the changes in this PR.
* [ ] All new and existing tests pass.
