### PR TITLE
Update Sparrow.ps1

### DIFF
--- a/Sparrow.ps1
+++ b/Sparrow.ps1
@@ -4,7 +4,7 @@
     [Parameter()]
     [string] $ExchangeEnvironment,
     [Parameter()]
-    [datetime] $StartDate = [DateTime]::UtcNow.AddYears(-1).AddMinutes(10),
+    [datetime] $StartDate = [DateTime]::UtcNow.AddDays(-364),
     [Parameter()]
     [datetime] $EndDate = [DateTime]::UtcNow,
     [Parameter()]


### PR DESCRIPTION
Changes start date to -364 days instead of -365 + 10 min, to give the tool more than 10 minutes to run.

Fixes #22 