### PR TITLE
Implements ability to run without O365

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,19 +24,7 @@ one.
 
 ## Pull requests ##
 
-If you choose to [submit a pull
-request](https://github.com/cisagov/sparrow/pulls), you will
-notice that our continuous integration (CI) system runs a fairly
-extensive set of linters and syntax checkers.  Your pull request may
-fail these checks, and that's OK.  If you want you can stop there and
-wait for us to make the necessary corrections to ensure your code
-passes the CI checks.
-
-If you want to make the changes yourself, or if you want to become a
-regular contributor, then you will want to set up
-[pre-commit](https://pre-commit.com/) on your local machine.  Once you
-do that, the CI checks will run locally before you even write your
-commit message.  This speeds up your development cycle considerably.
+If you would like to submit a pull request, please submit it [here](https://github.com/cisagov/sparrow/pulls).
 
 ## Public domain ##
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

Implements ability to run without O365

## 🗣 Description ##

Implements a switch `-NoO365` and adds `None` option to the ExchangeEnvironment context to allow users to only run the AzureAD checks if they do not have O365 in their environment.

## 💭 Motivation and Context ##

Multiple issues were raised by users without O365 in their AzureAD environment that still wished to run Sparrow against AzureAD.

## 🧪 Testing ##

Tested in an Azure AD environment from a Windows 10 machine with and without the switch. Account has the outlined permissions from README.md.

## ✅ Checklist ##

* [X] This PR has an informative and human-readable title.
* [X] Changes are limited to a single goal - _eschew scope creep!_
* [X] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [X] All relevant type-of-change labels have been added.
* [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.

Closes #32 
Closes #31 
Closes #29