### PR TITLE
detection to gather all azure app ids, and process via loop for sharepoint and exo investigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Sparrow.ps1 was created by CISA's Cloud Forensics team to help detect possible compromised accounts and applications in the Azure/m365 environment. The tool is intended for use by incident responders, and focuses on the narrow scope of user and application activity endemic to identity and authentication based attacks seen recently in multiple sectors. It is neither comprehensive nor exhaustive of available data, and is intended to narrow a larger set of available investigation modules and telemetry to those specific to recent attacks on federated identity sources and applications.
  
-Sparrow.ps1 will check and install the required PowerShell modules on the analysis machine, check the unified audit log in Azure/M365 for certain indicators of compromise (IoC's), list Azure AD domains, and check Azure service principals and their Microsoft Graph API permissions to identify potential malicious activity. The tool then outputs the data into multiple CSV files in a default directory.
+Sparrow.ps1 will check and install the required PowerShell modules on the analysis machine, check the unified audit log in Azure/M365 for certain indicators of compromise (IoC's), list Azure AD domains, and check Azure service principals and their Microsoft Graph API permissions to identify potential malicious activity. The tool then outputs the data into multiple CSV files that are located in the user's default home directory in a folder called 'ExportDir' (ie: Desktop/ExportDir).
+
+For more guidance on how to use Sparrow, please see: https://us-cert.cisa.gov/ncas/alerts/aa21-008a
 
 ## Requirements ##
 
@@ -21,6 +23,8 @@ The following AzureAD/m365 permissions are required to run Sparrow.ps1, and prov
      - View-Only Recipients
 
 To check for the MailItemsAccessed Operation, your tenant organization requires an Office 365 or Microsoft 365 E5/G5 license.
+
+Unified Audit Logs will need to be enabled.
 
 ## Installation ##
 

--- a/Sparrow.ps1
+++ b/Sparrow.ps1
@@ -154,6 +154,7 @@ Function Get-UALData {
     
     If ($AppIdInvestigation -eq "Yes"){
         $SusAppId = Read-Host "Enter the application's AppID to investigate"
+        Connect-AzureAD -AzureEnvironmentName $AzureEnvironment -Credential $Creds
         $AzureAppIds=Get-AzureADApplication -All
     } Else{
         Write-Host "Skipping AppID investigation"

--- a/Sparrow.ps1
+++ b/Sparrow.ps1
@@ -281,7 +281,7 @@ Function Get-UALData {
             $DirName=$AzureAppId.DisplayName
             $InvestigationMailExportDir=(Get-Item -Path $InvestigationExportParentDir).FullName+"\$DirName"
             
-            if (!(test-path $InvestigationExportDir))
+            if (!(test-path $InvestigationMailExportDir))
             {
                 new-item -Type Directory -Path $InvestigationMailExportDir -Force
             }

--- a/Sparrow.ps1
+++ b/Sparrow.ps1
@@ -361,7 +361,7 @@ Function Get-AzureSPAppRoles{
         [string] $AzureEnvironment,
         [Parameter(Mandatory=$true)]
         [string] $ExportDir,
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory=$false)]
         [string] $Credential
         )
 


### PR DESCRIPTION

used get-credential to store creds to variable to be passed to the -credential parameter of connection commandlets
variable gets set to $null at the end of the script.

added detection to gather all azure app ids, and feed to loop for investigation of all appIds
-sub feature of creating a folder for app investigations, and then creating sub-folders named with the app displayname.
mailitems and fileitems export is dumped into directory with corresponding displayname

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->
The goal is to reduce the manual interaction of this script overall. This was accomplished by reducing the number of times 
credentials would have to be entered by utilizing get-credential commandlet, and storing creds to variable.
Also, the option to investigate all Azure App IDs was added. This gathers all of the appids that are available
and performs the UAL query respectively.

## 💭 Motivation and Context ##

<!-- Why is this change required? -->
This change is required, because the current state of the code only allows for single appID investigation
By adding the option to investigate all AppIds, this gives more flexibility and reduces workload to correlate actions to investigate.
This will greatly increase accuracy, and give DFIR an option to look for all appid interaction, and not just a single appid at every script execution.
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
I used an AzureCloud and 0365Default environment to validate the proper function of the script, and correlation of data, after making my changes. Anyone with access to an Azure and 0365 tenant can test these changes.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Before modifying the code, I make an archive of the results that the script generates, prior to edits.
After passing my unit tests for my code, I verified that the content matches the offline archive, plus the addition of my data.
I do have an E5 license, so I was able to fully text the MailBoxItemsAccessed.
## 📷 Screenshots (if appropriate) ##

<!-- Remove this section and header if not needed -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [ ] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [ ] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [ ] All new and existing tests pass.
