### PR TITLE
Revamp of Azure AD UserAuthenticationMethod 16457 logic

### DIFF
--- a/Sparrow.ps1
+++ b/Sparrow.ps1
@@ -184,13 +184,6 @@ Function Get-UALData {
     #By default, it will show up as Consent_Operations_Export.csv       
     Export-UALData -ExportDir $ExportDir -UALInput $ConsentData -CsvName "Consent_Operations_Export" -WorkloadType "AAD"
 
-    #Searches for SAML token usage anomaly (UserAuthenticationValue of 16457) in the Unified Audit Logs
-    Write-Verbose "Searching for 16457 in UserLoggedIn and UserLoginFailed operations in the UAL."
-    $SAMLData = Search-UnifiedAuditLog -StartDate $StartDate -EndDate $EndDate -Operations "UserLoggedIn","UserLoginFailed" -ResultSize 5000 -FreeText "16457" | Select-Object -ExpandProperty AuditData | Convertfrom-Json
-    #You can modify the resultant CSV output by changing the -CsvName parameter
-    #By default, it will show up as SAMLToken_Operations_Export.csv      
-    Export-UALData -ExportDir $ExportDir -UALInput $SAMLData -CsvName "SAMLToken_Operations_Export" -WorkloadType "AAD"
-
     #Searches for PowerShell logins into mailboxes
     Write-Verbose "Searching for PowerShell logins into mailboxes in the UAL."
     $PSMailboxData = Search-UnifiedAuditLog -StartDate $StartDate -EndDate $EndDate -ResultSize 5000 -Operations "MailboxLogin" -FreeText "Powershell" | Select-Object -ExpandProperty AuditData | Convertfrom-Json

--- a/Sparrow.ps1
+++ b/Sparrow.ps1
@@ -187,9 +187,32 @@ Function Get-UALData {
     #By default, it will show up as Consent_Operations_Export.csv       
     Export-UALData -ExportDir $ExportDir -UALInput $ConsentData -CsvName "Consent_Operations_Export" -WorkloadType "AAD"
 
-    #Searches for SAML token usage anomaly (UserAuthenticationValue of 16457) in the Unified Audit 
-    $domains = Get-MsolDomain | where {$_.Authentication -eq "Federated"}
-    $domainsToFlag = $domains | %{ Get-MsolDomainFederationSettings -DomainName $_.Name | where {$_.SupportsMfa -ne $true}}
+  #Searches for SAML token usage anomaly (UserAuthenticationValue of 16457) in the Unified Audit
+  $federatedDomains = Get-MsolDomain | Where-Object {$_.Authentication -eq "Federated"}
+  # Get only root domains so we can get SupportMFA status
+  $rootDomains = $federatedDomains | Where-Object {$_.RootDomain -eq $null}
+  # Get root domains that don't support MFA, hence Federated MFA is not expected. Note: federated MFA is still possible when SupportsMFA is false, however less likely. Check your STS configuration.
+  $rootDomainsSupportMFAFalse = @()
+  
+  foreach ($rootDomain in $rootDomains)
+  {
+    $fedProps = Get-MsolDomainFederationSettings -DomainName $rootDomain.Name 
+    If ($fedProps.SupportsMfa -eq $False) {
+        $rootDomainsSupportMFAFalse += $rootDomain.Name
+    }
+  }
+# Add all child domains where its root is on the list
+$childDomainsSupportMFAFalse = @()
+$childDomains = $federatedDomains | Where-Object {$_.RootDomain -ne $null}
+
+foreach ($childDomain in $childDomains)
+{
+    if ($childDomain.RootDomain -in $rootDomainsSupportMFAFalse){
+        $childDomainsSupportMFAFalse += $childDomain.name
+    }
+}
+
+$domainsToFlag = $rootDomainsSupportMFAFalse + $childDomainsSupportMFAFalse
     If ($null -ne $domainsToFlag)
     {
         Write-Verbose "Searching for 16457 in UserLoggedIn and UserLoginFailed operations in the UAL."


### PR DESCRIPTION
## 🗣 Description ##

❌ 1⃣️6⃣️4⃣️5⃣️7⃣️
Having investigated this threat actor activity for quite some time, we have certainly found investigative utility in surfacing anomalous AAD authentications¹.
However, in our experience, only a subset of confirmed threat actor activity was associated with UserAuthenticationMethod 16457 - and even in those environments, other threat actor authentication methods were observed. The value, 16457, is driven by flags set providing context that isn't intended to have global meaning.

**Most importantly**, this 16457 value is *very common* globally and is unlikely to result in meaningful discovery of threat actor activity is isolation (without comparing it with the realm config or otherwise baselining an environment). Put simply, its value as an indicator is limited and tenant-specific - and **its inclusion is likely generating false positives & questions for Sparrow users.**

## 💭 Motivation and context ##

After thoroughly exploring its meaning & its global prevalence with internal teams in December, we removed the 16457 value from remaining internal hunting logic (and didn't release it in public Azure Sentinel logic). I recommend you consider removing it from this tool and from the text of Alert [AA21-008A](https://us-cert.cisa.gov/ncas/alerts/aa21-008a) as well.

Note: I see that @DeemOnSecurity acknowledged this value was [originally intended](https://github.com/cisagov/Sparrow/issues/20#issuecomment-754842442) as a potentially anomalous event in Issue #20 - but that nuance appears to have been lost on the broad user base. If replacement logic is desired, I expect our organizations can work together on alternate solutions!

Thanks in advance; and as an ex-CISA employee myself, I appreciate the development & release of actionable tools. Awesome stuff!
[-YOUR BOY CARR](https://twitter.com/ItsReallyNick)

## 🧪 Testing ##

N/A - only removing $SAMLData CSV query/output.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR. (NOTE: requested [AA21-008A](https://us-cert.cisa.gov/ncas/alerts/aa21-008a) edit above)
* [x] All new and existing tests pass.

## 📚 References ##

¹ [Understanding "Solorigate"'s Identity IOCs](https://techcommunity.microsoft.com/t5/azure-active-directory-identity/understanding-quot-solorigate-quot-s-identity-iocs-for-identity/ba-p/2007610)