### PR TITLE
renamed function name to check for PowerShell modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Unified Audit Logs will need to be enabled.
 
 Sparrow.ps1 does not require any extra steps for installation once the permissions detailed in Requirements are satisfied.
 
-The function, Check-PSModules, will check to see if the three required PowerShell modules are installed on the system and if not, it will use the default PowerShell repository on the system to reach out and install. If the modules are present but not imported, the script will also import the missing modules so that they are ready for use.
+The function, Import-PSModules, will check to see if the three required PowerShell modules are installed on the system and if not, it will use the default PowerShell repository on the system to reach out and install. If the modules are present but not imported, the script will also import the missing modules so that they are ready for use.
 
 The required PowerShell modules:
 


### PR DESCRIPTION
## 🗣 Description ##

The function name **Check-PSModules**, stated in the README.md file, does to equal the function name **Import-PSModules**, used in the PowerShell script Sparrow.ps1. 
https://github.com/cisagov/Sparrow/blob/73e560847e62d235fd00db8356f824660f1b2847/Sparrow.ps1#L20

## 💭 Motivation and context ##

- improve documentation

## 🧪 Testing ##

The Sparrow.ps1 file does not contain any function named Check-PSModules. 
I included the permalink to the correct fucntion name in PowerShell script Sparrow.ps1. 
https://github.com/cisagov/Sparrow/blob/73e560847e62d235fd00db8356f824660f1b2847/Sparrow.ps1#L20

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
